### PR TITLE
Implemented full Mix transaction support

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -176,8 +176,8 @@ pub async fn run() -> Result<()> {
 mod tests {
     use super::*;
     use crate::storage::traits::{
-        Block, Collection, CollectionKey, OwnershipRange, OwnershipUtxo, OwnershipUtxoSave,
-        StorageRead, StorageTx, StorageWrite,
+        Block, Collection, CollectionKey, OwnershipRange, OwnershipRangeWithGroup, OwnershipUtxo,
+        OwnershipUtxoSave, StorageRead, StorageTx, StorageWrite,
     };
     use bitcoin::hashes::Hash;
     use bitcoincore_rpc::Error as RpcError;
@@ -224,6 +224,14 @@ mod tests {
             _reg_txid: &str,
             _reg_vout: u32,
         ) -> Result<Vec<OwnershipUtxo>> {
+            Ok(vec![])
+        }
+
+        fn list_unspent_ownership_ranges_by_outpoint(
+            &self,
+            _reg_txid: &str,
+            _reg_vout: u32,
+        ) -> Result<Vec<OwnershipRangeWithGroup>> {
             Ok(vec![])
         }
 

--- a/src/cli/tx_cmd.rs
+++ b/src/cli/tx_cmd.rs
@@ -157,7 +157,7 @@ pub enum TxCmd {
             value_name = "ADDRESS:RANGES|ADDRESS:complement",
             required = true,
             num_args = 2..,
-            help = "Output mapping in the form ADDRESS:0..10,12 (end exclusive) or ADDRESS:complement (repeat --output to define outputs in order)"
+            help = "Output mapping in the form ADDRESS:0..=10,12 (end inclusive) or ADDRESS:complement (repeat --output to define outputs in order)"
         )]
         outputs: Vec<String>,
         #[arg(

--- a/src/cli/tx_cmd.rs
+++ b/src/cli/tx_cmd.rs
@@ -139,4 +139,47 @@ pub enum TxCmd {
         )]
         passphrase: Option<String>,
     },
+    #[command(
+        about = "Mix BRC-721 assets across outputs (explicit mapping)",
+        long_about = "Create and broadcast a mix transaction that maps NFT indices across the provided ownership inputs to specific outputs using an OP_RETURN payload. Exactly one output mapping must be marked as the complement set."
+    )]
+    Mix {
+        #[arg(
+            long = "outpoint",
+            value_name = "TXID:VOUT",
+            required = true,
+            num_args = 1..,
+            help = "Ownership outpoint(s) to spend (repeat --outpoint for multiple)"
+        )]
+        outpoints: Vec<String>,
+        #[arg(
+            long = "output",
+            value_name = "ADDRESS:RANGES|ADDRESS:complement",
+            required = true,
+            num_args = 2..,
+            help = "Output mapping in the form ADDRESS:0..10,12 (end exclusive) or ADDRESS:complement (repeat --output to define outputs in order)"
+        )]
+        outputs: Vec<String>,
+        #[arg(
+            long = "dust-sat",
+            value_name = "SATOSHI",
+            default_value_t = 546,
+            help = "Satoshis to attach to each asset-carrying output"
+        )]
+        dust_sat: u64,
+        #[arg(
+            long = "fee-rate",
+            value_name = "SAT/VB",
+            required = false,
+            help = "Fee rate in sat/vB (optional)"
+        )]
+        fee_rate: Option<f64>,
+        #[arg(
+            long,
+            value_name = "PASSPHRASE",
+            help = "Passphrase for signing",
+            required = false
+        )]
+        passphrase: Option<String>,
+    },
 }

--- a/src/cli/tx_cmd.rs
+++ b/src/cli/tx_cmd.rs
@@ -141,7 +141,7 @@ pub enum TxCmd {
     },
     #[command(
         about = "Mix BRC-721 assets across outputs (explicit mapping)",
-        long_about = "Create and broadcast a mix transaction that maps NFT indices across the provided ownership inputs to specific outputs using an OP_RETURN payload. Exactly one output mapping must be marked as the complement set."
+        long_about = "Create and broadcast a mix transaction that maps NFT indices across the provided ownership inputs to specific outputs using an OP_RETURN payload. Exactly one output mapping must be marked as the complement set. Use a single output with :complement to merge all tokens into one output."
     )]
     Mix {
         #[arg(
@@ -156,8 +156,8 @@ pub enum TxCmd {
             long = "output",
             value_name = "ADDRESS:RANGES|ADDRESS:complement",
             required = true,
-            num_args = 2..,
-            help = "Output mapping in the form ADDRESS:0..=10,12 (end inclusive) or ADDRESS:complement (repeat --output to define outputs in order)"
+            num_args = 1..,
+            help = "Output mapping in the form ADDRESS:0..=10,12 (end inclusive) or ADDRESS:complement (repeat --output to define outputs in order; a single complement output merges all tokens)"
         )]
         outputs: Vec<String>,
         #[arg(

--- a/src/commands/tx.rs
+++ b/src/commands/tx.rs
@@ -3,7 +3,8 @@ use std::str::FromStr;
 use super::CommandRunner;
 use crate::storage::traits::{CollectionKey, StorageRead};
 use crate::types::{
-    Brc721OpReturnOutput, Brc721Payload, RegisterCollectionData, RegisterOwnershipData, SlotRanges,
+    Brc721OpReturnOutput, Brc721Payload, IndexRanges, MixData, RegisterCollectionData,
+    RegisterOwnershipData, SlotRanges,
 };
 use crate::wallet::passphrase::prompt_passphrase_once;
 use crate::{cli, context, wallet::brc721_wallet::Brc721Wallet};
@@ -53,6 +54,20 @@ impl CommandRunner for cli::TxCmd {
                 fee_rate,
                 passphrase,
             } => run_send_assets(ctx, to, outpoints, *dust_sat, *fee_rate, passphrase.clone()),
+            cli::TxCmd::Mix {
+                outpoints,
+                outputs,
+                dust_sat,
+                fee_rate,
+                passphrase,
+            } => run_mix(
+                ctx,
+                outpoints,
+                outputs,
+                *dust_sat,
+                *fee_rate,
+                passphrase.clone(),
+            ),
         }
     }
 }
@@ -255,6 +270,123 @@ fn run_send_assets(
     Ok(())
 }
 
+fn run_mix(
+    ctx: &context::Context,
+    outpoints: &[String],
+    outputs: &[String],
+    dust_sat: u64,
+    fee_rate: Option<f64>,
+    passphrase: Option<String>,
+) -> Result<()> {
+    let db_path = ctx.data_dir.join("brc721.sqlite");
+    if !db_path.exists() {
+        return Err(anyhow!(
+            "scanner database not found at {} (run the daemon to build an index)",
+            db_path.to_string_lossy()
+        ));
+    }
+
+    let token_outpoints = parse_outpoints(outpoints)?;
+    if token_outpoints.is_empty() {
+        return Err(anyhow!("at least one --outpoint is required"));
+    }
+    let unique = token_outpoints.iter().cloned().collect::<BTreeSet<_>>();
+    if unique.len() != token_outpoints.len() {
+        return Err(anyhow!("duplicate --outpoint provided"));
+    }
+
+    let (output_addresses, mix_data) = parse_mix_outputs(outputs, ctx.network)?;
+
+    let storage = crate::storage::SqliteStorage::new(&db_path);
+
+    let mut total_tokens = 0u128;
+    for outpoint in &token_outpoints {
+        let groups = storage
+            .load_unspent_ownership_utxos_with_ranges_by_outpoint(
+                &outpoint.txid.to_string(),
+                outpoint.vout,
+            )
+            .with_context(|| {
+                format!(
+                    "query ownership ranges for {}:{}",
+                    outpoint.txid, outpoint.vout
+                )
+            })?;
+        if groups.is_empty() {
+            return Err(anyhow!(
+                "outpoint {}:{} not found in the BRC-721 index (not an ownership UTXO, or not scanned yet)",
+                outpoint.txid,
+                outpoint.vout
+            ));
+        }
+
+        for (_utxo, ranges) in groups {
+            for range in ranges {
+                let len = range
+                    .slot_end
+                    .checked_sub(range.slot_start)
+                    .and_then(|delta| delta.checked_add(1))
+                    .ok_or_else(|| anyhow!("token range length overflow"))?;
+                total_tokens = total_tokens
+                    .checked_add(len)
+                    .ok_or_else(|| anyhow!("token count overflow"))?;
+            }
+        }
+    }
+
+    mix_data.validate_token_count(total_tokens)?;
+
+    let wallet = load_wallet(ctx)?;
+    let wallet_utxos = wallet.list_unspent(0).context("list wallet UTXOs")?;
+
+    let wallet_outpoints = wallet_utxos
+        .iter()
+        .map(|utxo| OutPoint {
+            txid: utxo.txid,
+            vout: utxo.vout,
+        })
+        .collect::<BTreeSet<_>>();
+
+    for outpoint in &token_outpoints {
+        if !wallet_outpoints.contains(outpoint) {
+            return Err(anyhow!(
+                "outpoint {}:{} is not spendable by this wallet",
+                outpoint.txid,
+                outpoint.vout
+            ));
+        }
+    }
+
+    let dust_amount = Amount::from_sat(dust_sat);
+    let payments = output_addresses
+        .into_iter()
+        .map(|address| (address, dust_amount))
+        .collect::<Vec<_>>();
+    let output_count = payments.len();
+
+    let op_return = Brc721OpReturnOutput::new(Brc721Payload::Mix(mix_data))
+        .into_txout()
+        .context("build mix op_return output")?;
+
+    let passphrase = resolve_passphrase(passphrase);
+    let tx = wallet
+        .build_mix_tx(&token_outpoints, op_return, payments, fee_rate, passphrase)
+        .context("build mix tx")?;
+
+    let txid = wallet.broadcast(&tx)?;
+    log::info!(
+        "✅ Mixed {} ownership outpoint(s) into {} output(s) (txid: {})",
+        token_outpoints.len(),
+        output_count,
+        txid
+    );
+    log::info!(
+        "ℹ️ Ownership changes are reflected by the scanner after {} confirmation(s).",
+        ctx.confirmations
+    );
+    Ok(())
+}
+
 fn load_wallet(ctx: &context::Context) -> Result<Brc721Wallet> {
     Brc721Wallet::load(&ctx.data_dir, ctx.network, &ctx.rpc_url, ctx.auth.clone())
 }
@@ -309,6 +441,57 @@ fn compute_wallet_token_outpoints_to_lock(
         .difference(&spending_set)
         .cloned()
         .collect())
+}
+
+fn parse_mix_outputs(
+    outputs: &[String],
+    network: bitcoin::Network,
+) -> Result<(Vec<Address>, MixData)> {
+    if outputs.len() < 2 {
+        return Err(anyhow!("mix requires at least two --output entries"));
+    }
+
+    let mut addresses = Vec::with_capacity(outputs.len());
+    let mut ranges = Vec::with_capacity(outputs.len());
+    let mut complement_index: Option<usize> = None;
+
+    for (index, output) in outputs.iter().enumerate() {
+        let (address_str, range_str) = output.split_once(':').ok_or_else(|| {
+            anyhow!("invalid output '{output}' (expected ADDRESS:RANGES or ADDRESS:complement)")
+        })?;
+
+        let address = Address::from_str(address_str)?.require_network(network)?;
+
+        if range_str.eq_ignore_ascii_case("complement")
+            || range_str.eq_ignore_ascii_case("rest")
+            || range_str == "*"
+        {
+            if complement_index.is_some() {
+                return Err(anyhow!(
+                    "mix requires exactly one complement output (duplicate at index {})",
+                    index + 1
+                ));
+            }
+            complement_index = Some(index);
+            addresses.push(address);
+            ranges.push(Vec::new());
+            continue;
+        }
+
+        let parsed = IndexRanges::from_str(range_str)
+            .map_err(|err| anyhow!("invalid output ranges '{range_str}': {err}"))?;
+        addresses.push(address);
+        ranges.push(parsed.into_ranges());
+    }
+
+    let Some(complement_index) = complement_index else {
+        return Err(anyhow!(
+            "mix requires exactly one complement output (use ADDRESS:complement)"
+        ));
+    };
+
+    let data = MixData::new(ranges, complement_index)?;
+    Ok((addresses, data))
 }
 
 #[cfg(test)]

--- a/src/commands/tx.rs
+++ b/src/commands/tx.rs
@@ -357,6 +357,10 @@ fn run_mix(
         }
     }
 
+    let lock_outpoints =
+        compute_wallet_token_outpoints_to_lock(&storage, &wallet_utxos, &token_outpoints)
+            .context("compute lock set")?;
+
     let dust_amount = Amount::from_sat(dust_sat);
     let payments = output_addresses
         .into_iter()
@@ -370,7 +374,14 @@ fn run_mix(
 
     let passphrase = resolve_passphrase(passphrase);
     let tx = wallet
-        .build_mix_tx(&token_outpoints, op_return, payments, fee_rate, passphrase)
+        .build_mix_tx(
+            &token_outpoints,
+            op_return,
+            payments,
+            fee_rate,
+            &lock_outpoints,
+            passphrase,
+        )
         .context("build mix tx")?;
 
     let txid = wallet.broadcast(&tx)?;

--- a/src/commands/tx.rs
+++ b/src/commands/tx.rs
@@ -447,8 +447,8 @@ fn parse_mix_outputs(
     outputs: &[String],
     network: bitcoin::Network,
 ) -> Result<(Vec<Address>, MixData)> {
-    if outputs.len() < 2 {
-        return Err(anyhow!("mix requires at least two --output entries"));
+    if outputs.is_empty() {
+        return Err(anyhow!("mix requires at least one --output entry"));
     }
 
     let mut addresses = Vec::with_capacity(outputs.len());

--- a/src/core.rs
+++ b/src/core.rs
@@ -75,8 +75,8 @@ impl<C: BitcoinRpc, S: Storage, P: BlockParser<S::Tx>> Core<C, S, P> {
 mod tests {
     use super::*;
     use crate::storage::traits::{
-        Collection, CollectionKey, OwnershipRange, OwnershipUtxo, OwnershipUtxoSave, StorageRead,
-        StorageWrite,
+        Collection, CollectionKey, OwnershipRange, OwnershipRangeWithGroup, OwnershipUtxo,
+        OwnershipUtxoSave, StorageRead, StorageWrite,
     };
     use crate::types::Brc721Error;
     use bitcoin::blockdata::constants::genesis_block;
@@ -135,6 +135,14 @@ mod tests {
             _reg_txid: &str,
             _reg_vout: u32,
         ) -> Result<Vec<OwnershipUtxo>> {
+            Ok(vec![])
+        }
+
+        fn list_unspent_ownership_ranges_by_outpoint(
+            &self,
+            _reg_txid: &str,
+            _reg_vout: u32,
+        ) -> Result<Vec<OwnershipRangeWithGroup>> {
             Ok(vec![])
         }
 

--- a/src/parser/brc721_parser.rs
+++ b/src/parser/brc721_parser.rs
@@ -16,12 +16,9 @@ pub struct Brc721Parser;
 fn unique_groups_from_ranges(ranges: &[OwnershipRangeWithGroup]) -> Vec<(CollectionKey, H160)> {
     let mut groups = Vec::new();
     for range in ranges {
-        if groups
-            .iter()
-            .any(|(collection_id, base_h160)| {
-                *collection_id == range.collection_id && *base_h160 == range.base_h160
-            })
-        {
+        if groups.iter().any(|(collection_id, base_h160)| {
+            *collection_id == range.collection_id && *base_h160 == range.base_h160
+        }) {
             continue;
         }
         groups.push((range.collection_id.clone(), range.base_h160));
@@ -29,15 +26,11 @@ fn unique_groups_from_ranges(ranges: &[OwnershipRangeWithGroup]) -> Vec<(Collect
     groups
 }
 
-fn merge_ordered_ranges(
-    ranges: &[OwnershipRangeWithGroup],
-) -> Vec<OwnershipRangeWithGroup> {
-    let mut out = Vec::new();
+fn merge_ordered_ranges(ranges: &[OwnershipRangeWithGroup]) -> Vec<OwnershipRangeWithGroup> {
+    let mut out: Vec<OwnershipRangeWithGroup> = Vec::new();
     for range in ranges {
         if let Some(last) = out.last_mut() {
-            if last.collection_id == range.collection_id
-                && last.base_h160 == range.base_h160
-            {
+            if last.collection_id == range.collection_id && last.base_h160 == range.base_h160 {
                 if let Some(next) = last.slot_end.checked_add(1) {
                     if next == range.slot_start {
                         last.slot_end = range.slot_end;

--- a/src/parser/brc721_parser.rs
+++ b/src/parser/brc721_parser.rs
@@ -1,5 +1,7 @@
 use crate::bitcoin_rpc::BitcoinRpc;
-use crate::storage::traits::{OwnershipUtxoSave, StorageRead, StorageWrite};
+use crate::storage::traits::{
+    CollectionKey, OwnershipRangeWithGroup, OwnershipUtxoSave, StorageRead, StorageWrite,
+};
 use crate::types::{
     h160_from_script_pubkey, parse_brc721_tx, Brc721Error, Brc721Payload, Brc721Tx,
 };
@@ -10,6 +12,85 @@ use ethereum_types::H160;
 use crate::parser::{BlockParser, TokenInput};
 
 pub struct Brc721Parser;
+
+fn unique_groups_from_ranges(ranges: &[OwnershipRangeWithGroup]) -> Vec<(CollectionKey, H160)> {
+    let mut groups = Vec::new();
+    for range in ranges {
+        if groups
+            .iter()
+            .any(|(collection_id, base_h160)| {
+                *collection_id == range.collection_id && *base_h160 == range.base_h160
+            })
+        {
+            continue;
+        }
+        groups.push((range.collection_id.clone(), range.base_h160));
+    }
+    groups
+}
+
+fn merge_ordered_ranges(
+    ranges: &[OwnershipRangeWithGroup],
+) -> Vec<OwnershipRangeWithGroup> {
+    let mut out = Vec::new();
+    for range in ranges {
+        if let Some(last) = out.last_mut() {
+            if last.collection_id == range.collection_id
+                && last.base_h160 == range.base_h160
+            {
+                if let Some(next) = last.slot_end.checked_add(1) {
+                    if next == range.slot_start {
+                        last.slot_end = range.slot_end;
+                        continue;
+                    }
+                }
+            }
+        }
+        out.push(range.clone());
+    }
+    out
+}
+
+fn save_ranges_for_output<S: StorageWrite>(
+    storage: &S,
+    txid: &str,
+    vout: u32,
+    owner_h160: H160,
+    block_height: u64,
+    tx_index: u32,
+    ranges: &[OwnershipRangeWithGroup],
+) -> Result<(), Brc721Error> {
+    let groups = unique_groups_from_ranges(ranges);
+    for (collection_id, base_h160) in groups {
+        storage
+            .save_ownership_utxo(OwnershipUtxoSave {
+                collection_id: &collection_id,
+                owner_h160,
+                base_h160,
+                reg_txid: txid,
+                reg_vout: vout,
+                created_height: block_height,
+                created_tx_index: tx_index,
+            })
+            .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
+    }
+
+    let merged = merge_ordered_ranges(ranges);
+    for range in merged {
+        storage
+            .save_ownership_range(
+                txid,
+                vout,
+                &range.collection_id,
+                range.base_h160,
+                range.slot_start,
+                range.slot_end,
+            )
+            .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
+    }
+
+    Ok(())
+}
 
 impl Brc721Parser {
     pub fn new() -> Self {
@@ -36,25 +117,17 @@ impl Brc721Parser {
             let prev_txid = prevout.txid.to_string();
             let prev_vout = prevout.vout;
 
-            let utxos = storage
-                .list_unspent_ownership_utxos_by_outpoint(&prev_txid, prev_vout)
+            let ranges = storage
+                .list_unspent_ownership_ranges_by_outpoint(&prev_txid, prev_vout)
                 .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
-            if utxos.is_empty() {
+            if ranges.is_empty() {
                 continue;
-            }
-
-            let mut groups = Vec::with_capacity(utxos.len());
-            for utxo in utxos {
-                let ranges = storage
-                    .list_ownership_ranges(&utxo)
-                    .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
-                groups.push((utxo, ranges));
             }
 
             token_inputs.push(TokenInput {
                 prev_txid,
                 prev_vout,
-                groups,
+                ranges,
             });
         }
 
@@ -152,41 +225,25 @@ impl Brc721Parser {
             // Burn: no valid outputs, assign tokens to the null owner on vout0 (provably unspendable OP_RETURN).
             let burn_vout = 0u32;
             for input in token_inputs {
+                let group_count = unique_groups_from_ranges(&input.ranges).len();
                 log::info!(
                     "🔥 Burning token input {}:{} (groups={}) at {}#{}",
                     input.prev_txid,
                     input.prev_vout,
-                    input.groups.len(),
+                    group_count,
                     block_height,
                     tx_index
                 );
 
-                for (utxo, ranges) in input.groups {
-                    storage
-                        .save_ownership_utxo(OwnershipUtxoSave {
-                            collection_id: &utxo.collection_id,
-                            owner_h160: H160::zero(),
-                            base_h160: utxo.base_h160,
-                            reg_txid: &spend_txid,
-                            reg_vout: burn_vout,
-                            created_height: block_height,
-                            created_tx_index: tx_index,
-                        })
-                        .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
-
-                    for range in ranges {
-                        storage
-                            .save_ownership_range(
-                                &spend_txid,
-                                burn_vout,
-                                &utxo.collection_id,
-                                utxo.base_h160,
-                                range.slot_start,
-                                range.slot_end,
-                            )
-                            .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
-                    }
-                }
+                save_ranges_for_output(
+                    storage,
+                    &spend_txid,
+                    burn_vout,
+                    H160::zero(),
+                    block_height,
+                    tx_index,
+                    &input.ranges,
+                )?;
             }
 
             return Ok(());
@@ -203,6 +260,7 @@ impl Brc721Parser {
             };
 
             let dest_owner_h160 = h160_from_script_pubkey(&dest_txout.script_pubkey);
+            let group_count = unique_groups_from_ranges(&input.ranges).len();
 
             log::info!(
                 "🔁 Implicit transfer input {}:{} -> outpoint {}:{} (groups={}) at {}#{}",
@@ -210,37 +268,20 @@ impl Brc721Parser {
                 input.prev_vout,
                 spend_txid,
                 dest_vout,
-                input.groups.len(),
+                group_count,
                 block_height,
                 tx_index
             );
 
-            for (utxo, ranges) in input.groups {
-                storage
-                    .save_ownership_utxo(OwnershipUtxoSave {
-                        collection_id: &utxo.collection_id,
-                        owner_h160: dest_owner_h160,
-                        base_h160: utxo.base_h160,
-                        reg_txid: &spend_txid,
-                        reg_vout: dest_vout,
-                        created_height: block_height,
-                        created_tx_index: tx_index,
-                    })
-                    .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
-
-                for range in ranges {
-                    storage
-                        .save_ownership_range(
-                            &spend_txid,
-                            dest_vout,
-                            &utxo.collection_id,
-                            utxo.base_h160,
-                            range.slot_start,
-                            range.slot_end,
-                        )
-                        .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
-                }
-            }
+            save_ranges_for_output(
+                storage,
+                &spend_txid,
+                dest_vout,
+                dest_owner_h160,
+                block_height,
+                tx_index,
+                &input.ranges,
+            )?;
         }
 
         Ok(())
@@ -904,6 +945,135 @@ mod tests {
     }
 
     #[test]
+    fn mix_preserves_input_order_across_groups() {
+        use bitcoin::{absolute, transaction, PubkeyHash, Sequence, Witness};
+        use std::str::FromStr;
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let storage =
+            crate::storage::SqliteStorage::new(temp_dir.path().join("brc721_mix_order.db"));
+        storage.init().expect("init db");
+
+        let collection_id = CollectionKey::new(840_000, 0);
+        let base_a = H160::from_str("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+        let base_b = H160::from_str("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").unwrap();
+
+        let prev_txid = bitcoin::Txid::from_str(
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        )
+        .unwrap();
+        let prev_txid_str = prev_txid.to_string();
+
+        let tx = storage.begin_tx().unwrap();
+        tx.save_ownership_utxo(OwnershipUtxoSave {
+            collection_id: &collection_id,
+            owner_h160: H160::from_low_u64_be(1),
+            base_h160: base_a,
+            reg_txid: &prev_txid_str,
+            reg_vout: 0,
+            created_height: 1,
+            created_tx_index: 0,
+        })
+        .unwrap();
+        tx.save_ownership_utxo(OwnershipUtxoSave {
+            collection_id: &collection_id,
+            owner_h160: H160::from_low_u64_be(2),
+            base_h160: base_b,
+            reg_txid: &prev_txid_str,
+            reg_vout: 0,
+            created_height: 1,
+            created_tx_index: 1,
+        })
+        .unwrap();
+
+        // Insert ranges in an interleaved order: A0, B100, A1.
+        tx.save_ownership_range(&prev_txid_str, 0, &collection_id, base_a, 0, 0)
+            .unwrap();
+        tx.save_ownership_range(&prev_txid_str, 0, &collection_id, base_b, 100, 100)
+            .unwrap();
+        tx.save_ownership_range(&prev_txid_str, 0, &collection_id, base_a, 1, 1)
+            .unwrap();
+
+        let mix = crate::types::MixData::new(
+            vec![
+                vec![crate::types::mix::IndexRange { start: 1, end: 2 }],
+                Vec::new(),
+            ],
+            1,
+        )
+        .expect("mix payload");
+        let op_return =
+            crate::types::Brc721OpReturnOutput::new(crate::types::Brc721Payload::Mix(mix))
+                .into_txout()
+                .unwrap();
+
+        let dest_script_1 = ScriptBuf::new_p2pkh(&PubkeyHash::hash(b"dest1"));
+        let dest_script_2 = ScriptBuf::new_p2pkh(&PubkeyHash::hash(b"dest2"));
+
+        let spending_tx = Transaction {
+            version: transaction::Version(2),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: prev_txid,
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence(0xffffffff),
+                witness: Witness::default(),
+            }],
+            output: vec![
+                op_return,
+                TxOut {
+                    value: Amount::from_sat(5_000),
+                    script_pubkey: dest_script_1.clone(),
+                },
+                TxOut {
+                    value: Amount::from_sat(5_000),
+                    script_pubkey: dest_script_2.clone(),
+                },
+            ],
+        };
+
+        let spend_txid_str = spending_tx.compute_txid().to_string();
+
+        let mut block = genesis_block(Network::Regtest);
+        block.txdata = vec![spending_tx];
+        let parser = Brc721Parser::new();
+        let rpc = DummyRpc;
+        parser.parse_block(&tx, &block, 210, &rpc).unwrap();
+        tx.commit().unwrap();
+
+        let output1 = storage
+            .list_unspent_ownership_utxos_by_outpoint(&spend_txid_str, 1)
+            .unwrap();
+        assert_eq!(output1.len(), 1);
+        assert_eq!(output1[0].base_h160, base_b);
+        let ranges1 = storage.list_ownership_ranges(&output1[0]).unwrap();
+        assert_eq!(
+            ranges1,
+            vec![OwnershipRange {
+                slot_start: 100,
+                slot_end: 100
+            }]
+        );
+
+        let output2 = storage
+            .list_unspent_ownership_utxos_by_outpoint(&spend_txid_str, 2)
+            .unwrap();
+        assert_eq!(output2.len(), 1);
+        assert_eq!(output2[0].base_h160, base_a);
+        let ranges2 = storage.list_ownership_ranges(&output2[0]).unwrap();
+        assert_eq!(
+            ranges2,
+            vec![OwnershipRange {
+                slot_start: 0,
+                slot_end: 1
+            }]
+        );
+    }
+
+    #[test]
     fn mix_invalid_does_not_fallback_to_implicit_transfer() {
         use bitcoin::{absolute, transaction, PubkeyHash, Sequence, Witness};
         use std::str::FromStr;
@@ -1050,6 +1220,14 @@ mod tests {
             _reg_txid: &str,
             _reg_vout: u32,
         ) -> anyhow::Result<Vec<OwnershipUtxo>> {
+            Ok(vec![])
+        }
+
+        fn list_unspent_ownership_ranges_by_outpoint(
+            &self,
+            _reg_txid: &str,
+            _reg_vout: u32,
+        ) -> anyhow::Result<Vec<OwnershipRangeWithGroup>> {
             Ok(vec![])
         }
 

--- a/src/parser/mix.rs
+++ b/src/parser/mix.rs
@@ -34,9 +34,7 @@ impl OutputAssignment {
         slot_end: u128,
     ) {
         if let Some(last) = self.slices.last_mut() {
-            if last.collection_id == *collection_id
-                && last.base_h160 == base_h160
-            {
+            if last.collection_id == *collection_id && last.base_h160 == base_h160 {
                 if let Some(next) = last.slot_end.checked_add(1) {
                     if next == slot_start {
                         last.slot_end = slot_end;
@@ -57,12 +55,9 @@ impl OutputAssignment {
     fn unique_groups(&self) -> Vec<(CollectionKey, H160)> {
         let mut groups = Vec::new();
         for slice in &self.slices {
-            if groups
-                .iter()
-                .any(|(collection_id, base_h160)| {
-                    *collection_id == slice.collection_id && *base_h160 == slice.base_h160
-                })
-            {
+            if groups.iter().any(|(collection_id, base_h160)| {
+                *collection_id == slice.collection_id && *base_h160 == slice.base_h160
+            }) {
                 continue;
             }
             groups.push((slice.collection_id.clone(), slice.base_h160));

--- a/src/parser/mix.rs
+++ b/src/parser/mix.rs
@@ -1,0 +1,282 @@
+use crate::parser::TokenInput;
+use crate::storage::traits::{CollectionKey, OwnershipRange, OwnershipUtxoSave, StorageWrite};
+use crate::types::{h160_from_script_pubkey, Brc721Error, Brc721Tx, MixData};
+use ethereum_types::H160;
+
+#[derive(Clone)]
+struct InputSegment {
+    collection_id: CollectionKey,
+    base_h160: H160,
+    slot_start: u128,
+    index_start: u128,
+    index_end: u128,
+}
+
+#[derive(Default)]
+struct OutputAssignment {
+    groups: Vec<OutputGroup>,
+}
+
+#[derive(Clone)]
+struct OutputGroup {
+    collection_id: CollectionKey,
+    base_h160: H160,
+    ranges: Vec<OwnershipRange>,
+}
+
+impl OutputAssignment {
+    fn push_range(
+        &mut self,
+        collection_id: &CollectionKey,
+        base_h160: H160,
+        slot_start: u128,
+        slot_end: u128,
+    ) {
+        let mut group = self
+            .groups
+            .iter_mut()
+            .find(|group| group.collection_id == *collection_id && group.base_h160 == base_h160);
+
+        if group.is_none() {
+            self.groups.push(OutputGroup {
+                collection_id: collection_id.clone(),
+                base_h160,
+                ranges: Vec::new(),
+            });
+            group = self.groups.last_mut();
+        }
+
+        let group = group.expect("group must exist");
+        if let Some(last) = group.ranges.last_mut() {
+            if last.slot_end + 1 == slot_start {
+                last.slot_end = slot_end;
+                return;
+            }
+        }
+
+        group.ranges.push(OwnershipRange {
+            slot_start,
+            slot_end,
+        });
+    }
+}
+
+struct ExplicitRange {
+    start: u128,
+    end: u128,
+    output_index: usize,
+}
+
+pub fn digest<S: StorageWrite>(
+    payload: &MixData,
+    brc721_tx: &Brc721Tx<'_>,
+    token_inputs: &[TokenInput],
+    input_count: usize,
+    storage: &S,
+    block_height: u64,
+    tx_index: u32,
+) -> Result<bool, Brc721Error> {
+    let txid = brc721_tx.txid().to_string();
+
+    if let Err(err) = brc721_tx.validate() {
+        log::warn!("mix validation failed (txid={}, err={})", txid, err);
+        return Ok(false);
+    }
+
+    if token_inputs.is_empty() {
+        log::warn!("mix has no ownership inputs (txid={})", txid);
+        return Ok(false);
+    }
+
+    if input_count != token_inputs.len() {
+        log::warn!(
+            "mix inputs must all be ownership UTXOs (txid={}, input_count={}, ownership_inputs={})",
+            txid,
+            input_count,
+            token_inputs.len()
+        );
+        return Ok(false);
+    }
+
+    let mut segments = Vec::new();
+    let mut index_cursor: u128 = 0;
+
+    for input in token_inputs {
+        for (utxo, ranges) in &input.groups {
+            for range in ranges {
+                let len = range
+                    .slot_end
+                    .checked_sub(range.slot_start)
+                    .and_then(|delta| delta.checked_add(1))
+                    .ok_or_else(|| {
+                        Brc721Error::TxError("mix input range length overflow".into())
+                    })?;
+
+                let index_start = index_cursor;
+                let index_end = index_cursor
+                    .checked_add(len)
+                    .ok_or_else(|| Brc721Error::TxError("mix index overflow".into()))?;
+
+                segments.push(InputSegment {
+                    collection_id: utxo.collection_id.clone(),
+                    base_h160: utxo.base_h160,
+                    slot_start: range.slot_start,
+                    index_start,
+                    index_end,
+                });
+                index_cursor = index_end;
+            }
+        }
+    }
+
+    let total_tokens = index_cursor;
+    if let Err(err) = payload.validate_token_count(total_tokens) {
+        log::warn!(
+            "mix token range validation failed (txid={}, token_count={}, err={})",
+            txid,
+            total_tokens,
+            err
+        );
+        return Ok(false);
+    }
+
+    let output_count = payload.output_ranges.len();
+    for output_index in 0..output_count {
+        let vout = (output_index + 1) as u32;
+        let Some(output) = brc721_tx.output(vout) else {
+            log::warn!(
+                "mix missing output {} (txid={}, vout={})",
+                output_index,
+                txid,
+                vout
+            );
+            return Ok(false);
+        };
+        if output.script_pubkey.is_op_return() {
+            log::warn!(
+                "mix output {} is op_return (txid={}, vout={})",
+                output_index,
+                txid,
+                vout
+            );
+            return Ok(false);
+        }
+    }
+
+    let mut explicit_ranges = Vec::new();
+    for (output_index, ranges) in payload.output_ranges.iter().enumerate() {
+        if output_index == payload.complement_index {
+            continue;
+        }
+        for range in ranges {
+            explicit_ranges.push(ExplicitRange {
+                start: range.start,
+                end: range.end,
+                output_index,
+            });
+        }
+    }
+    explicit_ranges.sort_by(|a, b| a.start.cmp(&b.start).then(a.end.cmp(&b.end)));
+
+    let mut assignments = Vec::with_capacity(output_count);
+    for _ in 0..output_count {
+        assignments.push(OutputAssignment::default());
+    }
+    let mut range_idx = 0usize;
+
+    for segment in segments {
+        let mut cursor = segment.index_start;
+        while cursor < segment.index_end {
+            while range_idx < explicit_ranges.len() && cursor >= explicit_ranges[range_idx].end {
+                range_idx += 1;
+            }
+
+            let (slice_end, output_index) = match explicit_ranges.get(range_idx) {
+                Some(range) if cursor >= range.start => {
+                    let end = segment.index_end.min(range.end);
+                    (end, range.output_index)
+                }
+                Some(range) => {
+                    let end = segment.index_end.min(range.start);
+                    (end, payload.complement_index)
+                }
+                None => (segment.index_end, payload.complement_index),
+            };
+
+            if slice_end <= cursor {
+                return Err(Brc721Error::TxError(
+                    "mix slice did not advance cursor".into(),
+                ));
+            }
+
+            let offset = cursor - segment.index_start;
+            let slice_len = slice_end - cursor;
+            let slot_start = segment
+                .slot_start
+                .checked_add(offset)
+                .ok_or_else(|| Brc721Error::TxError("mix slot overflow".into()))?;
+            let slot_end = slot_start
+                .checked_add(slice_len - 1)
+                .ok_or_else(|| Brc721Error::TxError("mix slot overflow".into()))?;
+
+            assignments[output_index].push_range(
+                &segment.collection_id,
+                segment.base_h160,
+                slot_start,
+                slot_end,
+            );
+
+            cursor = slice_end;
+        }
+    }
+
+    for (output_index, assignment) in assignments.into_iter().enumerate() {
+        if assignment.groups.is_empty() {
+            continue;
+        }
+
+        let vout = (output_index + 1) as u32;
+        let owner_h160 = brc721_tx
+            .output(vout)
+            .map(|output| h160_from_script_pubkey(&output.script_pubkey))
+            .unwrap_or_else(H160::zero);
+
+        for group in assignment.groups {
+            storage
+                .save_ownership_utxo(OwnershipUtxoSave {
+                    collection_id: &group.collection_id,
+                    owner_h160,
+                    base_h160: group.base_h160,
+                    reg_txid: &txid,
+                    reg_vout: vout,
+                    created_height: block_height,
+                    created_tx_index: tx_index,
+                })
+                .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
+
+            for range in group.ranges {
+                storage
+                    .save_ownership_range(
+                        &txid,
+                        vout,
+                        &group.collection_id,
+                        group.base_h160,
+                        range.slot_start,
+                        range.slot_end,
+                    )
+                    .map_err(|e| Brc721Error::StorageError(e.to_string()))?;
+            }
+        }
+    }
+
+    log::info!(
+        "mix indexed (txid={}, inputs={}, outputs={}, token_count={}, complement_output={})",
+        txid,
+        input_count,
+        output_count,
+        total_tokens,
+        payload.complement_index + 1
+    );
+
+    Ok(true)
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,17 @@
 mod brc721_parser;
+mod mix;
 mod register_collection;
 mod register_ownership;
 mod traits;
 
 pub use brc721_parser::Brc721Parser;
 pub use traits::BlockParser;
+
+use crate::storage::traits::{OwnershipRange, OwnershipUtxo};
+
+#[derive(Debug)]
+pub(crate) struct TokenInput {
+    pub prev_txid: String,
+    pub prev_vout: u32,
+    pub groups: Vec<(OwnershipUtxo, Vec<OwnershipRange>)>,
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,11 +7,11 @@ mod traits;
 pub use brc721_parser::Brc721Parser;
 pub use traits::BlockParser;
 
-use crate::storage::traits::{OwnershipRange, OwnershipUtxo};
+use crate::storage::traits::OwnershipRangeWithGroup;
 
 #[derive(Debug)]
 pub(crate) struct TokenInput {
     pub prev_txid: String,
     pub prev_vout: u32,
-    pub groups: Vec<(OwnershipUtxo, Vec<OwnershipRange>)>,
+    pub ranges: Vec<OwnershipRangeWithGroup>,
 }

--- a/src/rest/handlers.rs
+++ b/src/rest/handlers.rs
@@ -582,12 +582,14 @@ mod tests {
                                 && utxo.base_h160 == *base_h160
                         })
                 })
-                .map(|(_, _, collection_id, base_h160, range)| OwnershipRangeWithGroup {
-                    collection_id: collection_id.clone(),
-                    base_h160: *base_h160,
-                    slot_start: range.slot_start,
-                    slot_end: range.slot_end,
-                })
+                .map(
+                    |(_, _, collection_id, base_h160, range)| OwnershipRangeWithGroup {
+                        collection_id: collection_id.clone(),
+                        base_h160: *base_h160,
+                        slot_start: range.slot_start,
+                        slot_end: range.slot_end,
+                    },
+                )
                 .collect())
         }
 

--- a/src/rest/handlers.rs
+++ b/src/rest/handlers.rs
@@ -322,8 +322,8 @@ mod tests {
 
     use crate::storage::{
         traits::{
-            Block, Collection, CollectionKey, OwnershipRange, OwnershipUtxo, OwnershipUtxoSave,
-            StorageRead, StorageTx, StorageWrite,
+            Block, Collection, CollectionKey, OwnershipRange, OwnershipRangeWithGroup,
+            OwnershipUtxo, OwnershipUtxoSave, StorageRead, StorageTx, StorageWrite,
         },
         Storage,
     };
@@ -561,6 +561,36 @@ mod tests {
                 .collect())
         }
 
+        fn list_unspent_ownership_ranges_by_outpoint(
+            &self,
+            reg_txid: &str,
+            reg_vout: u32,
+        ) -> anyhow::Result<Vec<OwnershipRangeWithGroup>> {
+            let utxos = self.ownership_utxos.read().unwrap();
+            let ranges = self.ownership_ranges.read().unwrap();
+
+            Ok(ranges
+                .iter()
+                .filter(|(txid, vout, collection_id, base_h160, _)| {
+                    *txid == reg_txid
+                        && *vout == reg_vout
+                        && utxos.iter().any(|utxo| {
+                            utxo.spent_txid.is_none()
+                                && utxo.reg_txid == *txid
+                                && utxo.reg_vout == *vout
+                                && utxo.collection_id == *collection_id
+                                && utxo.base_h160 == *base_h160
+                        })
+                })
+                .map(|(_, _, collection_id, base_h160, range)| OwnershipRangeWithGroup {
+                    collection_id: collection_id.clone(),
+                    base_h160: *base_h160,
+                    slot_start: range.slot_start,
+                    slot_end: range.slot_end,
+                })
+                .collect())
+        }
+
         fn list_ownership_ranges(
             &self,
             utxo: &OwnershipUtxo,
@@ -654,6 +684,14 @@ mod tests {
             _reg_txid: &str,
             _reg_vout: u32,
         ) -> anyhow::Result<Vec<OwnershipUtxo>> {
+            Err(anyhow!("not implemented"))
+        }
+
+        fn list_unspent_ownership_ranges_by_outpoint(
+            &self,
+            _reg_txid: &str,
+            _reg_vout: u32,
+        ) -> anyhow::Result<Vec<OwnershipRangeWithGroup>> {
             Err(anyhow!("not implemented"))
         }
 

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -217,6 +217,7 @@ fn db_list_unspent_ownership_utxos_by_outpoint(
     reg_txid: &str,
     reg_vout: u32,
 ) -> rusqlite::Result<Vec<OwnershipUtxo>> {
+    // Preserve insertion order so mix ordering remains stable across transfers.
     let mut stmt = conn.prepare(
         r#"
         SELECT
@@ -247,7 +248,7 @@ fn db_list_ownership_ranges(
             AND reg_vout = ?2
             AND collection_id = ?3
             AND base_h160 = ?4
-        ORDER BY slot_start, slot_end
+        ORDER BY rowid
         "#,
     )?;
     let mapped = stmt

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -35,6 +35,14 @@ pub struct OwnershipRange {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnershipRangeWithGroup {
+    pub collection_id: CollectionKey,
+    pub base_h160: H160,
+    pub slot_start: u128,
+    pub slot_end: u128,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Block {
     pub height: u64,
     pub hash: String,
@@ -49,6 +57,11 @@ pub trait StorageRead {
         reg_txid: &str,
         reg_vout: u32,
     ) -> Result<Vec<OwnershipUtxo>>;
+    fn list_unspent_ownership_ranges_by_outpoint(
+        &self,
+        reg_txid: &str,
+        reg_vout: u32,
+    ) -> Result<Vec<OwnershipRangeWithGroup>>;
     fn list_ownership_ranges(&self, utxo: &OwnershipUtxo) -> Result<Vec<OwnershipRange>>;
     fn find_unspent_ownership_utxo_for_slot(
         &self,

--- a/src/types/brc721_command.rs
+++ b/src/types/brc721_command.rs
@@ -5,6 +5,7 @@ use super::Brc721Error;
 pub enum Brc721Command {
     RegisterCollection = 0x00,
     RegisterOwnership = 0x01,
+    Mix = 0x02,
 }
 
 impl std::convert::TryFrom<u8> for Brc721Command {
@@ -14,6 +15,7 @@ impl std::convert::TryFrom<u8> for Brc721Command {
         match value {
             0x00 => Ok(Brc721Command::RegisterCollection),
             0x01 => Ok(Brc721Command::RegisterOwnership),
+            0x02 => Ok(Brc721Command::Mix),
             x => Err(Brc721Error::UnknownCommand(x)),
         }
     }
@@ -58,5 +60,12 @@ mod tests {
         let cmd = Brc721Command::RegisterOwnership;
         let value: u8 = cmd.into();
         assert_eq!(value, 0x01);
+    }
+
+    #[test]
+    fn test_mix_command_value() {
+        let cmd = Brc721Command::Mix;
+        let value: u8 = cmd.into();
+        assert_eq!(value, 0x02);
     }
 }

--- a/src/types/mix.rs
+++ b/src/types/mix.rs
@@ -1,0 +1,438 @@
+use crate::types::varint96::VarInt96;
+use crate::types::Brc721Error;
+use bitcoin::Transaction;
+use std::{fmt, str::FromStr};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexRange {
+    pub start: u128,
+    pub end: u128,
+}
+
+#[derive(Debug)]
+pub struct IndexRangesParseError {
+    message: String,
+}
+
+impl IndexRangesParseError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for IndexRangesParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for IndexRangesParseError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexRanges(Vec<IndexRange>);
+
+impl IndexRanges {
+    pub(crate) fn into_ranges(self) -> Vec<IndexRange> {
+        self.0
+    }
+}
+
+impl FromStr for IndexRanges {
+    type Err = IndexRangesParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let raw = s.trim();
+        if raw.is_empty() {
+            return Err(IndexRangesParseError::new(
+                "index ranges cannot be empty (expected e.g. '0..10,11,20..25')",
+            ));
+        }
+
+        let mut ranges = Vec::new();
+        for part in raw.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                return Err(IndexRangesParseError::new(
+                    "index ranges contains an empty range (expected e.g. '0..10,11,20..25')",
+                ));
+            }
+
+            if let Some((start, end)) = part.split_once("..") {
+                let start = parse_index_str(start)?;
+                let end = parse_index_str(end)?;
+
+                if start >= end {
+                    return Err(IndexRangesParseError::new(format!(
+                        "invalid index range '{part}': start {start} must be less than end {end}"
+                    )));
+                }
+
+                ranges.push(IndexRange { start, end });
+            } else {
+                let single = parse_index_str(part)?;
+                if single == VarInt96::MAX_VALUE {
+                    return Err(IndexRangesParseError::new(format!(
+                        "single index {single} is too large to express as a range"
+                    )));
+                }
+                ranges.push(IndexRange {
+                    start: single,
+                    end: single + 1,
+                });
+            }
+        }
+
+        if ranges.len() > 1 {
+            let mut sorted = ranges.clone();
+            sorted.sort_by(|a, b| a.start.cmp(&b.start).then(a.end.cmp(&b.end)));
+
+            let mut last = &sorted[0];
+            for current in sorted.iter().skip(1) {
+                if current.start < last.end {
+                    return Err(IndexRangesParseError::new(format!(
+                        "overlapping index ranges are not allowed: {}..{} overlaps {}..{}",
+                        last.start, last.end, current.start, current.end
+                    )));
+                }
+                last = current;
+            }
+        }
+
+        Ok(Self(ranges))
+    }
+}
+
+fn parse_index_str(s: &str) -> Result<u128, IndexRangesParseError> {
+    let raw = s.trim();
+    if raw.is_empty() {
+        return Err(IndexRangesParseError::new("index cannot be empty"));
+    }
+    let index: u128 = raw
+        .parse()
+        .map_err(|_| IndexRangesParseError::new(format!("invalid index '{raw}'")))?;
+    if index > VarInt96::MAX_VALUE {
+        return Err(IndexRangesParseError::new(format!(
+            "index {index} exceeds max {}",
+            VarInt96::MAX_VALUE
+        )));
+    }
+    Ok(index)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MixData {
+    pub output_ranges: Vec<Vec<IndexRange>>,
+    pub complement_index: usize,
+}
+
+impl MixData {
+    pub fn new(
+        output_ranges: Vec<Vec<IndexRange>>,
+        complement_index: usize,
+    ) -> Result<Self, Brc721Error> {
+        let data = Self {
+            output_ranges,
+            complement_index,
+        };
+        data.validate_basic()?;
+        Ok(data)
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.validate_basic()
+            .expect("mix payload must be valid before serialization");
+
+        let output_count = VarInt96::new(self.output_ranges.len() as u128)
+            .expect("validated output count must fit 96-bit varint");
+        let mut out = Vec::with_capacity(output_count.size());
+        output_count.encode_into(&mut out);
+
+        for (index, ranges) in self.output_ranges.iter().enumerate() {
+            let range_count = if index == self.complement_index {
+                0u128
+            } else {
+                ranges.len() as u128
+            };
+            let range_count_varint =
+                VarInt96::new(range_count).expect("validated range count must fit 96-bit varint");
+            range_count_varint.encode_into(&mut out);
+
+            if index == self.complement_index {
+                continue;
+            }
+
+            for range in ranges {
+                VarInt96::new(range.start)
+                    .expect("validated range start must fit 96-bit varint")
+                    .encode_into(&mut out);
+                VarInt96::new(range.end)
+                    .expect("validated range end must fit 96-bit varint")
+                    .encode_into(&mut out);
+            }
+        }
+
+        out
+    }
+
+    pub fn validate_in_tx(&self, bitcoin_tx: &Transaction) -> Result<(), Brc721Error> {
+        self.validate_basic()?;
+
+        let output_count = bitcoin_tx.output.len();
+        if output_count < self.output_ranges.len() + 1 {
+            return Err(Brc721Error::TxError(format!(
+                "mix output count {} out of bounds (tx outputs={})",
+                self.output_ranges.len(),
+                output_count
+            )));
+        }
+
+        Ok(())
+    }
+
+    pub fn max_explicit_end(&self) -> Option<u128> {
+        self.output_ranges
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| *idx != self.complement_index)
+            .flat_map(|(_, ranges)| ranges.iter())
+            .map(|range| range.end)
+            .max()
+    }
+
+    pub fn validate_token_count(&self, total_tokens: u128) -> Result<(), Brc721Error> {
+        let max_end = self.max_explicit_end().ok_or_else(|| {
+            Brc721Error::TxError("mix requires at least one explicit range".into())
+        })?;
+
+        if max_end == 0 {
+            return Err(Brc721Error::TxError(
+                "mix requires at least one non-empty explicit range".into(),
+            ));
+        }
+
+        if total_tokens < max_end {
+            return Err(Brc721Error::TxError(format!(
+                "mix index range out of bounds (token_count={}, max_index={})",
+                total_tokens, max_end
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn validate_basic(&self) -> Result<(), Brc721Error> {
+        if self.output_ranges.len() < 2 {
+            return Err(Brc721Error::TxError(
+                "mix requires at least 2 output mappings".into(),
+            ));
+        }
+
+        if self.complement_index >= self.output_ranges.len() {
+            return Err(Brc721Error::TxError(
+                "mix complement index out of bounds".into(),
+            ));
+        }
+
+        for (index, ranges) in self.output_ranges.iter().enumerate() {
+            if index == self.complement_index {
+                if !ranges.is_empty() {
+                    return Err(Brc721Error::TxError(
+                        "mix complement output must not define explicit ranges".into(),
+                    ));
+                }
+                continue;
+            }
+
+            if ranges.is_empty() {
+                return Err(Brc721Error::TxError(
+                    "mix output ranges cannot be empty (use complement output instead)".into(),
+                ));
+            }
+
+            for range in ranges {
+                if range.start >= range.end {
+                    return Err(Brc721Error::TxError(format!(
+                        "invalid mix index range {}..{} (start must be less than end)",
+                        range.start, range.end
+                    )));
+                }
+                if range.start > VarInt96::MAX_VALUE || range.end > VarInt96::MAX_VALUE {
+                    return Err(Brc721Error::TxError(format!(
+                        "mix index range {}..{} exceeds max {}",
+                        range.start,
+                        range.end,
+                        VarInt96::MAX_VALUE
+                    )));
+                }
+            }
+        }
+
+        let mut all_ranges = Vec::new();
+        for (output_index, ranges) in self.output_ranges.iter().enumerate() {
+            if output_index == self.complement_index {
+                continue;
+            }
+            for range in ranges {
+                all_ranges.push((range.start, range.end));
+            }
+        }
+
+        if all_ranges.is_empty() {
+            return Err(Brc721Error::TxError(
+                "mix requires at least one explicit range".into(),
+            ));
+        }
+
+        all_ranges.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+        let mut last = all_ranges[0];
+        for current in all_ranges.into_iter().skip(1) {
+            if current.0 < last.1 {
+                return Err(Brc721Error::TxError(format!(
+                    "overlapping mix index ranges are not allowed: {}..{} overlaps {}..{}",
+                    last.0, last.1, current.0, current.1
+                )));
+            }
+            last = current;
+        }
+
+        Ok(())
+    }
+}
+
+impl TryFrom<&[u8]> for MixData {
+    type Error = Brc721Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let mut cursor = 0usize;
+
+        let output_count_raw = take_varint96(bytes, &mut cursor)?;
+        let output_count: usize = output_count_raw.try_into().map_err(|_| {
+            Brc721Error::TxError(format!(
+                "mix output_count {} out of range (max {})",
+                output_count_raw,
+                usize::MAX
+            ))
+        })?;
+        if output_count < 2 {
+            return Err(Brc721Error::TxError(format!(
+                "mix output_count must be at least 2, got {}",
+                output_count
+            )));
+        }
+
+        let mut output_ranges = Vec::with_capacity(output_count);
+        let mut complement_index: Option<usize> = None;
+
+        for index in 0..output_count {
+            let range_count_raw = take_varint96(bytes, &mut cursor)?;
+            let range_count: usize = range_count_raw.try_into().map_err(|_| {
+                Brc721Error::TxError(format!(
+                    "mix range_count {} out of range (max {})",
+                    range_count_raw,
+                    usize::MAX
+                ))
+            })?;
+
+            if range_count == 0 {
+                if complement_index.is_some() {
+                    return Err(Brc721Error::TxError(
+                        "mix cannot define multiple complement outputs".into(),
+                    ));
+                }
+                complement_index = Some(index);
+                output_ranges.push(Vec::new());
+                continue;
+            }
+
+            let mut ranges = Vec::with_capacity(range_count);
+            for _ in 0..range_count {
+                let start = take_varint96(bytes, &mut cursor)?;
+                let end = take_varint96(bytes, &mut cursor)?;
+                if start >= end {
+                    return Err(Brc721Error::TxError(format!(
+                        "invalid mix index range {}..{} (start must be less than end)",
+                        start, end
+                    )));
+                }
+                ranges.push(IndexRange { start, end });
+            }
+
+            output_ranges.push(ranges);
+        }
+
+        if cursor != bytes.len() {
+            return Err(Brc721Error::InvalidLength(cursor, bytes.len()));
+        }
+
+        let complement_index = complement_index.ok_or_else(|| {
+            Brc721Error::TxError("mix requires exactly one complement output".into())
+        })?;
+
+        MixData::new(output_ranges, complement_index)
+    }
+}
+
+fn take_varint96(bytes: &[u8], cursor: &mut usize) -> Result<u128, Brc721Error> {
+    let slice = bytes
+        .get(*cursor..)
+        .ok_or_else(|| Brc721Error::TxError("varint96: cursor out of bounds".to_string()))?;
+    let (value, consumed) =
+        VarInt96::decode(slice).map_err(|e| Brc721Error::TxError(e.to_string()))?;
+    *cursor += consumed;
+    Ok(value.value())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn index_ranges_parse_allows_single_and_ranges() {
+        let ranges = IndexRanges::from_str("0..3, 5,7..10").expect("parse");
+        assert_eq!(
+            ranges,
+            IndexRanges(vec![
+                IndexRange { start: 0, end: 3 },
+                IndexRange { start: 5, end: 6 },
+                IndexRange { start: 7, end: 10 },
+            ])
+        );
+    }
+
+    #[test]
+    fn index_ranges_parse_rejects_overlap() {
+        let err = IndexRanges::from_str("0..3,2..4").unwrap_err();
+        assert!(err.to_string().contains("overlapping index ranges"));
+    }
+
+    #[test]
+    fn mix_roundtrip_ok() {
+        let data = MixData::new(
+            vec![
+                vec![IndexRange { start: 0, end: 2 }],
+                Vec::new(),
+                vec![IndexRange { start: 2, end: 4 }],
+            ],
+            1,
+        )
+        .expect("valid mix data");
+
+        let bytes = data.to_bytes();
+        let parsed = MixData::try_from(bytes.as_slice()).expect("parse ok");
+        assert_eq!(parsed, data);
+    }
+
+    #[test]
+    fn mix_rejects_multiple_complements() {
+        let bytes = vec![
+            2, // output_count
+            0, // output 0 (complement)
+            0, // output 1 (complement) -> invalid
+        ];
+        let res = MixData::try_from(bytes.as_slice());
+        assert!(res.is_err());
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,6 +4,7 @@ mod brc721_op_return_output;
 mod brc721_payload;
 mod brc721_token;
 mod brc721_tx;
+pub(crate) mod mix;
 mod register_collection;
 mod register_ownership;
 pub(crate) mod varint96;
@@ -15,6 +16,7 @@ pub use brc721_error::Brc721Error;
 pub use brc721_op_return_output::Brc721OpReturnOutput;
 pub use brc721_payload::Brc721Payload;
 pub use brc721_tx::{parse_brc721_tx, Brc721Tx};
+pub use mix::{IndexRanges, MixData};
 pub use register_collection::RegisterCollectionData;
 pub use register_ownership::{RegisterOwnershipData, SlotRanges};
 


### PR DESCRIPTION
  - Adds mix transaction support (command 0x02) with payload encoding/
    validation and index-range parsing (inclusive ..= accepted in CLI,
    encoded end‑exclusive on-chain) in src/types/mix.rs, src/types/        brc721_command.rs, src/types/brc721_payload.rs, src/types/mod.rs.    - Implements mix mapping/indexer path and deterministic range
    ordering in src/parser/mix.rs, src/parser/brc721_parser.rs, src/
    parser/mod.rs, src/storage/sqlite.rs.
  - Adds CLI tx mix flow plus PSBT builder support with ordered inputs     in src/cli/tx_cmd.rs, src/commands/tx.rs, src/wallet/                  brc721_wallet.rs, src/wallet/remote_wallet.rs.